### PR TITLE
Add probe_alignment_batch_max and use e-notation for learning rates

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -14,6 +14,7 @@ training:
   # Increasing this slows training overall even if
   # epochs go by faster.
   probe_batch_max: 32
+  probe_alignment_batch_max: 320
 
 # Number of epochs to train each stage.
 training_plan:

--- a/config/config.yml
+++ b/config/config.yml
@@ -78,8 +78,8 @@ loss_weight:
 # Learning rates are pre-tuned. Do not change these unless
 # you know what you are doing
 optimizer:
-  lr: 0.0001 # general learning rate
-  bert_lr: 0.00001 # learning rate for PLBERT
-  ft_lr: 0.00001 # learning rate for acoustic modules (i.e. decoder, textual_style_encoder and prosody_style_encoder)
-  alignment_lr: 0.00001 # alignment learning rate
-  text_encoder_lr: 0.00001 # text encoder pretraining lr
+  lr: 1e-4 # general learning rate
+  bert_lr: 1e-5 # learning rate for PLBERT
+  ft_lr: 1e-5 # learning rate for acoustic modules (i.e. decoder, textual_style_encoder and prosody_style_encoder)
+  alignment_lr: 1e-5 # alignment learning rate
+  text_encoder_lr: 1e-5 # text encoder pretraining lr

--- a/train/stylish_train/batch_manager.py
+++ b/train/stylish_train/batch_manager.py
@@ -28,6 +28,7 @@ class BatchManager:
         accelerator: Optional["Accelerator"] = None,
         *,
         probe_batch_max: int,
+        probe_alignment_batch_max: int,
         device: str,
         multispeaker: bool,
         text_cleaner: TextCleaner,
@@ -37,6 +38,7 @@ class BatchManager:
     ):
         self.train_path: str = dataset_config.train_data
         self.probe_batch_max: int = probe_batch_max
+        self.probe_alignment_batch_max: int = probe_alignment_batch_max
         self.log_dir: str = log_dir
         self.device: str = device
         self.multispeaker: bool = multispeaker
@@ -76,7 +78,7 @@ class BatchManager:
         train.stage.reset_batch_sizes()
         batch_size = self.probe_batch_max
         if train.manifest.stage == "alignment":
-            batch_size *= 10
+            batch_size = self.probe_alignment_batch_max
         # elif train.manifest.stage == "pre_acoustic":
         #     batch_size *= 5
         time_keys = sorted(list(self.time_bins.keys()))

--- a/train/stylish_train/config_loader.py
+++ b/train/stylish_train/config_loader.py
@@ -126,6 +126,8 @@ class OptimizerConfig(BaseModel):
     lr: float = Field(..., description="General learning rate.")
     bert_lr: float = Field(..., description="Learning rate for the PLBERT model.")
     ft_lr: float = Field(..., description="Learning rate for acoustic modules.")
+    alignment_lr: float = Field(..., description="Alignment learning rate.")
+    text_encoder_lr: float = Field(..., description="Text encoder pretraining learning rate.")
 
 
 ######## Model Configuration ########

--- a/train/stylish_train/config_loader.py
+++ b/train/stylish_train/config_loader.py
@@ -26,6 +26,10 @@ class TrainingConfig(BaseModel):
     probe_batch_max: int = Field(
         ..., description="Maximum batch size to attempt during bin probing."
     )
+    probe_alignment_batch_max: int = Field(
+        ..., description="Maximum alignment batch size to attempt during bin probing."
+    )
+
 
 
 class TrainingPlanConfig(BaseModel):

--- a/train/stylish_train/train.py
+++ b/train/stylish_train/train.py
@@ -158,6 +158,7 @@ def main(config_path, model_config_path, out_dir, stage, checkpoint, reset_stage
     train.batch_manager = BatchManager(
         train.config.dataset,
         train.out_dir,
+        probe_alignment_batch_max=train.config.training.probe_alignment_batch_max,
         probe_batch_max=train.config.training.probe_batch_max,
         device=train.config.training.device,
         accelerator=train.accelerator,


### PR DESCRIPTION
* `probe_alignment_batch_max` is added as on some cloud platform (e.g. Kaggle) the CPU is too weak to handle batch 320
* [E notation](https://en.wikipedia.org/wiki/Scientific_notation#E_notation) is a commonly used to present very small or large number - learning rate in this case. It has the form of `ae±n = a * 10^±n` (e.g. 1e-4 is 1 * 10^-4 or 0.0001)  (not to be confused with euler number)